### PR TITLE
[MLP-117] Integrate Autofac

### DIFF
--- a/Xamarin/MvvmSeed/MvvmSeed/MvvmSeed.Android/MvvmSeed.Android.csproj
+++ b/Xamarin/MvvmSeed/MvvmSeed/MvvmSeed.Android/MvvmSeed.Android.csproj
@@ -44,6 +44,12 @@
     <EmbedAssembliesIntoApk>True</EmbedAssembliesIntoApk>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Autofac, Version=4.4.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\packages\Autofac.4.4.0\lib\netstandard1.1\Autofac.dll</HintPath>
+    </Reference>
+    <Reference Include="Autofac.Extras.MvvmCross, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Autofac.Extras.MvvmCross.4.0.2\lib\portable45-net45+win8+wpa81\Autofac.Extras.MvvmCross.dll</HintPath>
+    </Reference>
     <Reference Include="Mono.Android" />
     <Reference Include="Mono.Android.Export" />
     <Reference Include="mscorlib" />
@@ -73,6 +79,8 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Xml" />
   </ItemGroup>
@@ -83,6 +91,7 @@
     <Compile Include="Views\SampleView.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
     <None Include="Resources\AboutResources.txt" />
     <None Include="Assets\AboutAssets.txt" />

--- a/Xamarin/MvvmSeed/MvvmSeed/MvvmSeed.Android/Setup.cs
+++ b/Xamarin/MvvmSeed/MvvmSeed/MvvmSeed.Android/Setup.cs
@@ -1,7 +1,11 @@
 using Android.Content;
+using Autofac;
+using Autofac.Extras.MvvmCross;
 using MvvmCross.Core.ViewModels;
 using MvvmCross.Droid.Platform;
+using MvvmCross.Platform.IoC;
 using MvvmSeed.Application;
+using MvvmSeed.Application.Modules;
 
 namespace MvvmSeed.Android
 {
@@ -9,9 +13,21 @@ namespace MvvmSeed.Android
     {
         public Setup(Context applicationContext) : base(applicationContext) { }
 
-        protected override IMvxApplication CreateApp()
+        protected override IMvxApplication CreateApp() => new App();
+
+        protected override IMvxIoCProvider CreateIocProvider()
         {
-            return new App();
+            var containerBuilder = new ContainerBuilder();
+            containerBuilder.RegisterModule<ApplicationModule>();
+
+            // This is an important step that ensures all the ViewModel's are loaded into the container. Without it, MvvmCross wouldn't register them by itself; needs more investigation.
+            var viewModelsAssembly = typeof(App).Assembly;
+            containerBuilder.RegisterAssemblyTypes(viewModelsAssembly)
+                .AssignableTo<MvxViewModel>()
+                .As<IMvxViewModel, MvxViewModel>()
+                .AsSelf();
+
+            return new AutofacMvxIocProvider(containerBuilder.Build());
         }
     }
 }

--- a/Xamarin/MvvmSeed/MvvmSeed/MvvmSeed.Android/app.config
+++ b/Xamarin/MvvmSeed/MvvmSeed/MvvmSeed.Android/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Autofac" publicKeyToken="17863af14b0044da" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.4.0.0" newVersion="4.4.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Xamarin/MvvmSeed/MvvmSeed/MvvmSeed.Android/packages.config
+++ b/Xamarin/MvvmSeed/MvvmSeed/MvvmSeed.Android/packages.config
@@ -1,7 +1,55 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Autofac" version="4.4.0" targetFramework="monoandroid71" />
+  <package id="Autofac.Extras.MvvmCross" version="4.0.2" targetFramework="monoandroid71" />
+  <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="monoandroid71" />
+  <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="monoandroid71" />
   <package id="MvvmCross" version="4.4.0" targetFramework="monoandroid71" />
   <package id="MvvmCross.Binding" version="4.4.0" targetFramework="monoandroid71" />
   <package id="MvvmCross.Core" version="4.4.0" targetFramework="monoandroid71" />
   <package id="MvvmCross.Platform" version="4.4.0" targetFramework="monoandroid71" />
+  <package id="NETStandard.Library" version="1.6.0" targetFramework="monoandroid71" />
+  <package id="System.AppContext" version="4.3.0" targetFramework="monoandroid71" />
+  <package id="System.Collections" version="4.3.0" targetFramework="monoandroid71" />
+  <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="monoandroid71" />
+  <package id="System.ComponentModel" version="4.3.0" targetFramework="monoandroid71" />
+  <package id="System.Console" version="4.3.0" targetFramework="monoandroid71" />
+  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="monoandroid71" />
+  <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="monoandroid71" />
+  <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="monoandroid71" />
+  <package id="System.Globalization" version="4.3.0" targetFramework="monoandroid71" />
+  <package id="System.Globalization.Calendars" version="4.3.0" targetFramework="monoandroid71" />
+  <package id="System.IO" version="4.3.0" targetFramework="monoandroid71" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="monoandroid71" />
+  <package id="System.IO.Compression.ZipFile" version="4.3.0" targetFramework="monoandroid71" />
+  <package id="System.IO.FileSystem" version="4.3.0" targetFramework="monoandroid71" />
+  <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="monoandroid71" />
+  <package id="System.Linq" version="4.3.0" targetFramework="monoandroid71" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="monoandroid71" />
+  <package id="System.Net.Http" version="4.3.1" targetFramework="monoandroid71" />
+  <package id="System.Net.Primitives" version="4.3.0" targetFramework="monoandroid71" />
+  <package id="System.Net.Sockets" version="4.3.0" targetFramework="monoandroid71" />
+  <package id="System.ObjectModel" version="4.3.0" targetFramework="monoandroid71" />
+  <package id="System.Reflection" version="4.3.0" targetFramework="monoandroid71" />
+  <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="monoandroid71" />
+  <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="monoandroid71" />
+  <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="monoandroid71" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="monoandroid71" />
+  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="monoandroid71" />
+  <package id="System.Runtime.Handles" version="4.3.0" targetFramework="monoandroid71" />
+  <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="monoandroid71" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="monoandroid71" />
+  <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="monoandroid71" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="monoandroid71" />
+  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="monoandroid71" />
+  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="monoandroid71" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="monoandroid71" />
+  <package id="System.Text.Encoding" version="4.3.0" targetFramework="monoandroid71" />
+  <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="monoandroid71" />
+  <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="monoandroid71" />
+  <package id="System.Threading" version="4.3.0" targetFramework="monoandroid71" />
+  <package id="System.Threading.Tasks" version="4.3.0" targetFramework="monoandroid71" />
+  <package id="System.Threading.Timer" version="4.3.0" targetFramework="monoandroid71" />
+  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="monoandroid71" />
+  <package id="System.Xml.XDocument" version="4.3.0" targetFramework="monoandroid71" />
 </packages>

--- a/Xamarin/MvvmSeed/MvvmSeed/MvvmSeed.Application/App.cs
+++ b/Xamarin/MvvmSeed/MvvmSeed/MvvmSeed.Application/App.cs
@@ -1,15 +1,9 @@
 ﻿using MvvmCross.Core.ViewModels;
-using MvvmCross.Platform;
-using MvvmSeed.Application.ViewModels;
 
 namespace MvvmSeed.Application
 {
     public class App : MvxApplication
     {
-        public App()
-        {
-            //TODO - Integrate Autofac and create separate modules
-            Mvx.RegisterSingleton<IMvxAppStart>(new MvxAppStart<SampleViewModel>());
-        }
+        //Placeholder for app-specific configurations
     }
 }

--- a/Xamarin/MvvmSeed/MvvmSeed/MvvmSeed.Application/Modules/ApplicationModule.cs
+++ b/Xamarin/MvvmSeed/MvvmSeed/MvvmSeed.Application/Modules/ApplicationModule.cs
@@ -1,0 +1,14 @@
+﻿using Autofac;
+using MvvmCross.Core.ViewModels;
+using MvvmSeed.Application.ViewModels;
+
+namespace MvvmSeed.Application.Modules
+{
+    public class ApplicationModule : Module
+    {
+        protected override void Load(ContainerBuilder cb)
+        {
+            cb.Register(c => new MvxAppStart<SampleViewModel>()).As<IMvxAppStart>().SingleInstance();
+        }
+    }
+}

--- a/Xamarin/MvvmSeed/MvvmSeed/MvvmSeed.Application/MvvmSeed.Application.csproj
+++ b/Xamarin/MvvmSeed/MvvmSeed/MvvmSeed.Application/MvvmSeed.Application.csproj
@@ -8,6 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Autofac" Version="4.4.0" />
+    <PackageReference Include="Autofac.Extras.MvvmCross" Version="4.0.2" />
     <PackageReference Include="MvvmCross" Version="4.4.0" />
   </ItemGroup>
 

--- a/Xamarin/MvvmSeed/MvvmSeed/MvvmSeed.UnitTests/MvvmSeed.UnitTests.csproj
+++ b/Xamarin/MvvmSeed/MvvmSeed/MvvmSeed.UnitTests/MvvmSeed.UnitTests.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170125-04" />
-    <PackageReference Include="xunit" Version="2.2.0-beta5-build3474" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-beta5-build1225" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Background

MvvmCross default container is very limited. Autofac provides much more flexibility and has multi-platform support.

## Changes done

- Replaced MvvmCross default container with Autofac
- Added .NET Standard reference on Android-specific assembly