### PR TITLE
[MLP-119] Integrate RealmDB

### DIFF
--- a/Xamarin/MvvmSeed/MvvmSeed/MvvmSeed.Android/FodyWeavers.xml
+++ b/Xamarin/MvvmSeed/MvvmSeed/MvvmSeed.Android/FodyWeavers.xml
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Weavers>
+  <RealmWeaver/>
+</Weavers>

--- a/Xamarin/MvvmSeed/MvvmSeed/MvvmSeed.Android/MvvmSeed.Android.csproj
+++ b/Xamarin/MvvmSeed/MvvmSeed/MvvmSeed.Android/MvvmSeed.Android.csproj
@@ -18,6 +18,8 @@
     <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
     <TargetFrameworkVersion>v7.1</TargetFrameworkVersion>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>
@@ -30,6 +32,14 @@
     <AndroidUseSharedRuntime>True</AndroidUseSharedRuntime>
     <AndroidLinkMode>None</AndroidLinkMode>
     <EmbedAssembliesIntoApk>False</EmbedAssembliesIntoApk>
+    <BundleAssemblies>False</BundleAssemblies>
+    <AndroidCreatePackagePerAbi>False</AndroidCreatePackagePerAbi>
+    <AndroidSupportedAbis>armeabi-v7a;x86;x86_64;arm64-v8a</AndroidSupportedAbis>
+    <Debugger>.Net (Xamarin)</Debugger>
+    <AotAssemblies>False</AotAssemblies>
+    <EnableLLVM>False</EnableLLVM>
+    <AndroidEnableMultiDex>False</AndroidEnableMultiDex>
+    <EnableProguard>False</EnableProguard>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>PdbOnly</DebugType>
@@ -42,6 +52,14 @@
     <AndroidUseSharedRuntime>False</AndroidUseSharedRuntime>
     <AndroidLinkMode>SdkOnly</AndroidLinkMode>
     <EmbedAssembliesIntoApk>True</EmbedAssembliesIntoApk>
+    <BundleAssemblies>False</BundleAssemblies>
+    <AndroidCreatePackagePerAbi>False</AndroidCreatePackagePerAbi>
+    <AndroidSupportedAbis>armeabi-v7a;x86;x86_64;arm64-v8a</AndroidSupportedAbis>
+    <Debugger>.Net (Xamarin)</Debugger>
+    <AotAssemblies>False</AotAssemblies>
+    <EnableLLVM>False</EnableLLVM>
+    <AndroidEnableMultiDex>False</AndroidEnableMultiDex>
+    <EnableProguard>False</EnableProguard>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Autofac, Version=4.4.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
@@ -49,6 +67,9 @@
     </Reference>
     <Reference Include="Autofac.Extras.MvvmCross, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Autofac.Extras.MvvmCross.4.0.2\lib\portable45-net45+win8+wpa81\Autofac.Extras.MvvmCross.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetCross.Memory.Unsafe, Version=0.2.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetCross.Memory.Unsafe.0.2.3.4\lib\netstandard1.0\DotNetCross.Memory.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Android" />
     <Reference Include="Mono.Android.Export" />
@@ -76,6 +97,15 @@
     </Reference>
     <Reference Include="MvvmCross.Platform.Droid, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\MvvmCross.Platform.4.4.0\lib\MonoAndroid\MvvmCross.Platform.Droid.dll</HintPath>
+    </Reference>
+    <Reference Include="Realm, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Realm.Database.1.1.0\lib\MonoAndroid44\Realm.dll</HintPath>
+    </Reference>
+    <Reference Include="Realm.Sync, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Realm.1.1.0\lib\MonoAndroid44\Realm.Sync.dll</HintPath>
+    </Reference>
+    <Reference Include="Remotion.Linq, Version=2.1.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b, processorArchitecture=MSIL">
+      <HintPath>..\packages\Remotion.Linq.2.1.1\lib\portable-net45+win+wpa81+wp80\Remotion.Linq.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -114,7 +144,21 @@
       <Name>MvvmSeed.Application</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="FodyWeavers.xml" />
+  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
+  <Import Project="..\packages\Fody.1.29.4\build\dotnet\Fody.targets" Condition="Exists('..\packages\Fody.1.29.4\build\dotnet\Fody.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Fody.1.29.4\build\dotnet\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.1.29.4\build\dotnet\Fody.targets'))" />
+    <Error Condition="!Exists('..\packages\Realm.Database.1.1.0\build\Realm.Database.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Realm.Database.1.1.0\build\Realm.Database.targets'))" />
+    <Error Condition="!Exists('..\packages\Realm.1.1.0\build\Realm.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Realm.1.1.0\build\Realm.targets'))" />
+  </Target>
+  <Import Project="..\packages\Realm.Database.1.1.0\build\Realm.Database.targets" Condition="Exists('..\packages\Realm.Database.1.1.0\build\Realm.Database.targets')" />
+  <Import Project="..\packages\Realm.1.1.0\build\Realm.targets" Condition="Exists('..\packages\Realm.1.1.0\build\Realm.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
      Other similar extension points exist, see Microsoft.Common.targets.
 		<Target Name="BeforeBuild">

--- a/Xamarin/MvvmSeed/MvvmSeed/MvvmSeed.Android/packages.config
+++ b/Xamarin/MvvmSeed/MvvmSeed/MvvmSeed.Android/packages.config
@@ -2,6 +2,8 @@
 <packages>
   <package id="Autofac" version="4.4.0" targetFramework="monoandroid71" />
   <package id="Autofac.Extras.MvvmCross" version="4.0.2" targetFramework="monoandroid71" />
+  <package id="DotNetCross.Memory.Unsafe" version="0.2.3.4" targetFramework="monoandroid71" />
+  <package id="Fody" version="1.29.4" targetFramework="monoandroid71" developmentDependency="true" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="monoandroid71" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="monoandroid71" />
   <package id="MvvmCross" version="4.4.0" targetFramework="monoandroid71" />
@@ -9,6 +11,9 @@
   <package id="MvvmCross.Core" version="4.4.0" targetFramework="monoandroid71" />
   <package id="MvvmCross.Platform" version="4.4.0" targetFramework="monoandroid71" />
   <package id="NETStandard.Library" version="1.6.0" targetFramework="monoandroid71" />
+  <package id="Realm" version="1.1.0" targetFramework="monoandroid71" />
+  <package id="Realm.Database" version="1.1.0" targetFramework="monoandroid71" />
+  <package id="Remotion.Linq" version="2.1.1" targetFramework="monoandroid71" />
   <package id="System.AppContext" version="4.3.0" targetFramework="monoandroid71" />
   <package id="System.Collections" version="4.3.0" targetFramework="monoandroid71" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="monoandroid71" />
@@ -26,6 +31,7 @@
   <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="monoandroid71" />
   <package id="System.Linq" version="4.3.0" targetFramework="monoandroid71" />
   <package id="System.Linq.Expressions" version="4.3.0" targetFramework="monoandroid71" />
+  <package id="System.Linq.Queryable" version="4.3.0" targetFramework="monoandroid71" />
   <package id="System.Net.Http" version="4.3.1" targetFramework="monoandroid71" />
   <package id="System.Net.Primitives" version="4.3.0" targetFramework="monoandroid71" />
   <package id="System.Net.Sockets" version="4.3.0" targetFramework="monoandroid71" />

--- a/Xamarin/MvvmSeed/MvvmSeed/MvvmSeed.Application/Data/RandomizedStringEntity.cs
+++ b/Xamarin/MvvmSeed/MvvmSeed/MvvmSeed.Application/Data/RandomizedStringEntity.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using Realms;
+
+namespace MvvmSeed.Application.Data
+{
+    public class RandomizedStringEntity : RealmObject
+    {
+        public const long DefaultRandomizedStringPrimaryKey = 1;
+
+        [PrimaryKey]
+        public long Id { get; set; }
+
+        public string LastTransformationValue { get; set; }
+
+        public int SampleTransformationCount { get; set; }
+
+        public DateTimeOffset LastTransformationTimestamp { get; set; }
+    }
+}

--- a/Xamarin/MvvmSeed/MvvmSeed/MvvmSeed.Application/FodyWeavers.xml
+++ b/Xamarin/MvvmSeed/MvvmSeed/MvvmSeed.Application/FodyWeavers.xml
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Weavers>
+  <RealmWeaver/>
+</Weavers>

--- a/Xamarin/MvvmSeed/MvvmSeed/MvvmSeed.Application/Modules/ApplicationModule.cs
+++ b/Xamarin/MvvmSeed/MvvmSeed/MvvmSeed.Application/Modules/ApplicationModule.cs
@@ -1,6 +1,9 @@
 ﻿using Autofac;
 using MvvmCross.Core.ViewModels;
+using MvvmSeed.Application.Services;
 using MvvmSeed.Application.ViewModels;
+using MvvmSeed.Domain.Services;
+using Realms;
 
 namespace MvvmSeed.Application.Modules
 {
@@ -9,6 +12,9 @@ namespace MvvmSeed.Application.Modules
         protected override void Load(ContainerBuilder cb)
         {
             cb.Register(c => new MvxAppStart<SampleViewModel>()).As<IMvxAppStart>().SingleInstance();
+            cb.Register(c => Realm.GetInstance()).As<Realm>().SingleInstance();
+
+            cb.Register(c => new StringRandomizerService(c.Resolve<Realm>())).As<IStringRandomizerService>();
         }
     }
 }

--- a/Xamarin/MvvmSeed/MvvmSeed/MvvmSeed.Application/MvvmSeed.Application.csproj
+++ b/Xamarin/MvvmSeed/MvvmSeed/MvvmSeed.Application/MvvmSeed.Application.csproj
@@ -5,12 +5,14 @@
     <PackageTargetFallback>
       $(PackageTargetFallback);portable-net45+netcore45
     </PackageTargetFallback>
+    <DebugType Condition="'$(TargetFramework)' != '' AND '$(TargetFramework)' != 'netcoreapp1.0'">Full</DebugType>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.4.0" />
     <PackageReference Include="Autofac.Extras.MvvmCross" Version="4.0.2" />
     <PackageReference Include="MvvmCross" Version="4.4.0" />
+    <PackageReference Include="Realm" Version="1.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Xamarin/MvvmSeed/MvvmSeed/MvvmSeed.Application/Services/StringRandomizerService.cs
+++ b/Xamarin/MvvmSeed/MvvmSeed/MvvmSeed.Application/Services/StringRandomizerService.cs
@@ -1,0 +1,53 @@
+﻿using MvvmSeed.Application.Data;
+using MvvmSeed.Domain.Services;
+using Realms;
+using System;
+using System.Linq;
+
+namespace MvvmSeed.Application.Services
+{
+    /// <summary>
+    /// Simple implementation of <see cref="IStringRandomizerService"/> that stores randomization info on a local database (Realm)
+    /// </summary>
+    public class StringRandomizerService : IStringRandomizerService
+    {
+        //TODO - When attempting to write UTs for this service, found out I couldn't because Realm class doesn't implement an interface/virtual methods. 
+        // Evalute alternatives (weaving Realm class, Moq alternatives, abstract Realm into ILocalStorage, etc)
+        private readonly Realm _realmDb;
+
+        public StringRandomizerService(Realm realmDb)
+        {
+            _realmDb = realmDb;
+        }
+
+        public string RandomizeString(string input)
+        {
+            var random = new Random();
+            var randomizedString = new string(input.ToCharArray().OrderBy(s => random.Next(2) % 2 == 0).ToArray());
+
+            var lastRandomizedString = _realmDb.Find<RandomizedStringEntity>(RandomizedStringEntity.DefaultRandomizedStringPrimaryKey) ?? new RandomizedStringEntity { Id = RandomizedStringEntity.DefaultRandomizedStringPrimaryKey };
+
+            //TODO - Concurrency tests when writing to DB
+            using (var transaction = _realmDb.BeginWrite())
+            {
+                lastRandomizedString.LastTransformationTimestamp = DateTimeOffset.UtcNow;
+                lastRandomizedString.SampleTransformationCount++;
+                lastRandomizedString.LastTransformationValue = randomizedString;
+                _realmDb.Add(lastRandomizedString, update: true);
+                transaction.Commit();
+            }
+            return randomizedString;
+        }
+
+        public DateTimeOffset LastRandomizationTimestamp => GetLastEntryFromDatabse()?.LastTransformationTimestamp ?? DateTimeOffset.MinValue;
+
+        public int RandomizationsCount => GetLastEntryFromDatabse()?.SampleTransformationCount ?? 0;
+
+        public string LastRandomizedValue => GetLastEntryFromDatabse()?.LastTransformationValue ?? "Hello World!";
+
+        private RandomizedStringEntity GetLastEntryFromDatabse()
+        {
+            return _realmDb.Find<RandomizedStringEntity>(RandomizedStringEntity.DefaultRandomizedStringPrimaryKey);
+        }
+    }
+}

--- a/Xamarin/MvvmSeed/MvvmSeed/MvvmSeed.Application/ViewModels/SampleViewModel.cs
+++ b/Xamarin/MvvmSeed/MvvmSeed/MvvmSeed.Application/ViewModels/SampleViewModel.cs
@@ -1,15 +1,19 @@
-﻿using System;
-using System.Linq;
-using MvvmCross.Core.ViewModels;
+﻿using MvvmCross.Core.ViewModels;
 using MvvmSeed.Application.ViewModels.Interfaces;
+using MvvmSeed.Domain.Services;
 
 namespace MvvmSeed.Application.ViewModels
 {
     public class SampleViewModel : MvxViewModel, ISampleViewModel
     {
-        public SampleViewModel()
+        private readonly IStringRandomizerService _stringRandomizerService;
+
+        public SampleViewModel(IStringRandomizerService stringRandomizerService)
         {
+            _stringRandomizerService = stringRandomizerService;
+
             DoSomethingCommand = new MvxCommand(DoSomethingCommandExecute);
+            SampleString = _stringRandomizerService.LastRandomizedValue;
         }
 
         public IMvxCommand DoSomethingCommand { get; }
@@ -19,13 +23,11 @@ namespace MvvmSeed.Application.ViewModels
             get { return _sampleString; }
             set { _sampleString = value; RaisePropertyChanged(); }
         }
-        private string _sampleString = "Hello World!";
+        private string _sampleString;
 
         private void DoSomethingCommandExecute()
         {
-            //Sample command, just randomly re-arranges SampleString to check databinding works properly
-            var random = new Random();
-            SampleString = new string(SampleString.ToCharArray().OrderBy(s => random.Next(2) % 2 == 0).ToArray());
+            SampleString = _stringRandomizerService.RandomizeString(SampleString);
         }
     }
 }

--- a/Xamarin/MvvmSeed/MvvmSeed/MvvmSeed.Domain/Services/IStringRandomizerService.cs
+++ b/Xamarin/MvvmSeed/MvvmSeed/MvvmSeed.Domain/Services/IStringRandomizerService.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+namespace MvvmSeed.Domain.Services
+{
+    public interface IStringRandomizerService
+    {
+        /// <summary>
+        /// Re-arranges string randomly
+        /// </summary>
+        /// <param name="input">String to be randomized</param>
+        /// <returns>Randomized string</returns>
+        string RandomizeString(string input);
+
+        /// <summary> Last randomization date and time</summary>
+        DateTimeOffset LastRandomizationTimestamp { get; }
+
+        /// <summary> Number of randomizations performed by this service </summary>
+        int RandomizationsCount { get; }
+
+        /// <summary> Last value provided by <see cref="RandomizeString"/> </summary>
+        string LastRandomizedValue { get; }
+    }
+}

--- a/Xamarin/MvvmSeed/MvvmSeed/MvvmSeed.UnitTests/MvvmSeed.UnitTests.csproj
+++ b/Xamarin/MvvmSeed/MvvmSeed/MvvmSeed.UnitTests/MvvmSeed.UnitTests.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Moq" Version="4.7.1" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>

--- a/Xamarin/MvvmSeed/MvvmSeed/MvvmSeed.UnitTests/ViewModels/SampleViewModelTest.cs
+++ b/Xamarin/MvvmSeed/MvvmSeed/MvvmSeed.UnitTests/ViewModels/SampleViewModelTest.cs
@@ -1,17 +1,21 @@
 using System;
 using System.Threading;
+using Moq;
 using MvvmSeed.Application.ViewModels;
+using MvvmSeed.Domain.Services;
 using Xunit;
 
 namespace MvvmSeed.UnitTests
 {
     public class SampleViewModelTest
     {
+        private readonly Mock<IStringRandomizerService> _stringRandomizerServiceMock = new Mock<IStringRandomizerService>();
+
         [Fact]
         public void DoSomethingCommand_ShouldTriggerPropertyChangedEvent_WhenDoSomethingCommandIsExecuted()
         {
             // Arrange
-            var sampleViewModel = new SampleViewModel();
+            var sampleViewModel = new SampleViewModel(_stringRandomizerServiceMock.Object);
             sampleViewModel.ShouldAlwaysRaiseInpcOnUserInterfaceThread(false);//UT lacks UI Dispatcher, we need to set this value to false if we want to receive notifications when there's no UI Dispatcher
             var eventWaiter = new AutoResetEvent(false);
             sampleViewModel.PropertyChanged += (s, e) =>


### PR DESCRIPTION
## Background

One of the objectives of this seed project is to provide a simple local storage mechanism. The obvious choices for mobile applications are Sqlite and Realm.

This PR shows how to integrate Realm and store/retrieve objects from it. The code is simple and maybe a bit stupid, but it's enough to show how Realm works.

## Changes Done

- Referenced Realm packages 
- Configured Realm weaver (yep, it relies on IL weaving to add all the boilerplate code within the build process, I've check the Fody module used for this and it adds extra instructions to classes inheriting from `RealmObject`)
- Created a Realm Entity called `RandomizedStringEntity `
- Created `IStringRandomizerService` and its implementation relying on Realm db

## Notes

I like it, I think it might be a better choice than Sqlite, but I would like to play a bit more with it. This is for early feedback.

One drawback is that  `Realm` class doesn't implement an interface, so a framework other than Moq will be required for UnitTests (one capable of mockings non virtual methods, like TypeMock).