### PR TITLE
[MLP-157] Added abstracted data provider, services and models examples

### DIFF
--- a/IOS/SwiftSeedProject/SwiftSeedProject.xcodeproj/project.pbxproj
+++ b/IOS/SwiftSeedProject/SwiftSeedProject.xcodeproj/project.pbxproj
@@ -7,7 +7,13 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		9C37A64C1E8BDA2300A0B8D7 /* DataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C37A64B1E8BDA2300A0B8D7 /* DataProvider.swift */; };
+		9C37A6521E8BF5D700A0B8D7 /* PersonDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C37A6511E8BF5D700A0B8D7 /* PersonDataModel.swift */; };
+		9C37A6541E8BF67E00A0B8D7 /* InMemoryDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C37A6531E8BF67E00A0B8D7 /* InMemoryDataProvider.swift */; };
 		9C53976E1E8070E7003C772F /* MSButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C53976D1E8070E7003C772F /* MSButton.swift */; };
+		9C81B4071E8AA47900C281B8 /* Person.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C81B4061E8AA47900C281B8 /* Person.swift */; };
+		9C81B40B1E8AA93C00C281B8 /* PersonService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C81B40A1E8AA93C00C281B8 /* PersonService.swift */; };
+		9C81B40E1E8AAF2F00C281B8 /* PersonTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C81B40D1E8AAF2F00C281B8 /* PersonTableViewCell.swift */; };
 		9CA0ADBC1E7C75EB00FD13C5 /* Second.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9CA0ADBB1E7C75EB00FD13C5 /* Second.storyboard */; };
 		9CA0ADBE1E7C75F700FD13C5 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CA0ADBD1E7C75F700FD13C5 /* ViewController.swift */; };
 		9CC3846F1E7C17AD00595171 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CC3846E1E7C17AD00595171 /* AppDelegate.swift */; };
@@ -15,10 +21,17 @@
 		9CC384791E7C17AD00595171 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9CC384771E7C17AD00595171 /* LaunchScreen.storyboard */; };
 		9CC3848F1E7C5DCE00595171 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9CC384721E7C17AD00595171 /* Main.storyboard */; };
 		9CC384901E7C5DCE00595171 /* First.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9CC3848A1E7C576800595171 /* First.storyboard */; };
+		9CE8071E1E89AEEF001DEF3E /* PersonTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CE8071D1E89AEEF001DEF3E /* PersonTableViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		9C37A64B1E8BDA2300A0B8D7 /* DataProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DataProvider.swift; path = Domain/Protocols/DataProvider.swift; sourceTree = "<group>"; };
+		9C37A6511E8BF5D700A0B8D7 /* PersonDataModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PersonDataModel.swift; path = Infrastructure/Persistence/Models/PersonDataModel.swift; sourceTree = "<group>"; };
+		9C37A6531E8BF67E00A0B8D7 /* InMemoryDataProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = InMemoryDataProvider.swift; path = Infrastructure/Persistence/Implementations/InMemoryDataProvider.swift; sourceTree = "<group>"; };
 		9C53976D1E8070E7003C772F /* MSButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MSButton.swift; path = Interfaces/Components/MSButton.swift; sourceTree = "<group>"; };
+		9C81B4061E8AA47900C281B8 /* Person.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Person.swift; path = Domain/Models/Person.swift; sourceTree = "<group>"; };
+		9C81B40A1E8AA93C00C281B8 /* PersonService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PersonService.swift; path = Domain/Services/PersonService.swift; sourceTree = "<group>"; };
+		9C81B40D1E8AAF2F00C281B8 /* PersonTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PersonTableViewCell.swift; path = Interfaces/ViewControllers/Person/PersonTableViewCell.swift; sourceTree = "<group>"; };
 		9CA0ADBB1E7C75EB00FD13C5 /* Second.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = Second.storyboard; path = Interfaces/Storyboards/Second.storyboard; sourceTree = "<group>"; };
 		9CA0ADBD1E7C75F700FD13C5 /* ViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ViewController.swift; path = Interfaces/ViewControllers/ViewController.swift; sourceTree = "<group>"; };
 		9CC3846B1E7C17AD00595171 /* SwiftSeedProject.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftSeedProject.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -28,6 +41,7 @@
 		9CC384781E7C17AD00595171 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		9CC3847A1E7C17AD00595171 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9CC3848B1E7C576800595171 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/First.storyboard; sourceTree = "<group>"; };
+		9CE8071D1E89AEEF001DEF3E /* PersonTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PersonTableViewController.swift; path = Interfaces/ViewControllers/PersonTableViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -41,12 +55,70 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		9C37A64E1E8BDB4500A0B8D7 /* Persistence */ = {
+			isa = PBXGroup;
+			children = (
+				9C37A6501E8BF1D400A0B8D7 /* Implementations */,
+				9C37A64F1E8BF1CF00A0B8D7 /* Models */,
+			);
+			name = Persistence;
+			sourceTree = "<group>";
+		};
+		9C37A64F1E8BF1CF00A0B8D7 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				9C37A6511E8BF5D700A0B8D7 /* PersonDataModel.swift */,
+			);
+			name = Models;
+			sourceTree = "<group>";
+		};
+		9C37A6501E8BF1D400A0B8D7 /* Implementations */ = {
+			isa = PBXGroup;
+			children = (
+				9C37A6531E8BF67E00A0B8D7 /* InMemoryDataProvider.swift */,
+			);
+			name = Implementations;
+			sourceTree = "<group>";
+		};
 		9C53976F1E8070ED003C772F /* Components */ = {
 			isa = PBXGroup;
 			children = (
 				9C53976D1E8070E7003C772F /* MSButton.swift */,
 			);
 			name = Components;
+			sourceTree = "<group>";
+		};
+		9C81B4051E8AA45700C281B8 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				9C81B4061E8AA47900C281B8 /* Person.swift */,
+			);
+			name = Models;
+			sourceTree = "<group>";
+		};
+		9C81B4091E8AA90A00C281B8 /* Services */ = {
+			isa = PBXGroup;
+			children = (
+				9C81B40A1E8AA93C00C281B8 /* PersonService.swift */,
+			);
+			name = Services;
+			sourceTree = "<group>";
+		};
+		9C81B40C1E8AAEF700C281B8 /* Persons */ = {
+			isa = PBXGroup;
+			children = (
+				9CE8071D1E89AEEF001DEF3E /* PersonTableViewController.swift */,
+				9C81B40D1E8AAF2F00C281B8 /* PersonTableViewCell.swift */,
+			);
+			name = Persons;
+			sourceTree = "<group>";
+		};
+		9C81B4121E8AD1D000C281B8 /* Protocols */ = {
+			isa = PBXGroup;
+			children = (
+				9C37A64B1E8BDA2300A0B8D7 /* DataProvider.swift */,
+			);
+			name = Protocols;
 			sourceTree = "<group>";
 		};
 		9CA0ADB91E7C75AD00FD13C5 /* Application */ = {
@@ -59,6 +131,9 @@
 		9CA0ADBA1E7C75BF00FD13C5 /* Domain */ = {
 			isa = PBXGroup;
 			children = (
+				9C81B4121E8AD1D000C281B8 /* Protocols */,
+				9C81B4091E8AA90A00C281B8 /* Services */,
+				9C81B4051E8AA45700C281B8 /* Models */,
 			);
 			name = Domain;
 			sourceTree = "<group>";
@@ -66,6 +141,7 @@
 		9CA0ADC11E7C763A00FD13C5 /* Infrastructure */ = {
 			isa = PBXGroup;
 			children = (
+				9C37A64E1E8BDB4500A0B8D7 /* Persistence */,
 			);
 			name = Infrastructure;
 			sourceTree = "<group>";
@@ -124,6 +200,7 @@
 		9CC384851E7C299E00595171 /* ViewControllers */ = {
 			isa = PBXGroup;
 			children = (
+				9C81B40C1E8AAEF700C281B8 /* Persons */,
 				9CA0ADBD1E7C75F700FD13C5 /* ViewController.swift */,
 			);
 			name = ViewControllers;
@@ -203,8 +280,15 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9C81B4071E8AA47900C281B8 /* Person.swift in Sources */,
+				9CE8071E1E89AEEF001DEF3E /* PersonTableViewController.swift in Sources */,
+				9C37A6521E8BF5D700A0B8D7 /* PersonDataModel.swift in Sources */,
+				9C37A64C1E8BDA2300A0B8D7 /* DataProvider.swift in Sources */,
+				9C81B40B1E8AA93C00C281B8 /* PersonService.swift in Sources */,
+				9C37A6541E8BF67E00A0B8D7 /* InMemoryDataProvider.swift in Sources */,
 				9CA0ADBE1E7C75F700FD13C5 /* ViewController.swift in Sources */,
 				9C53976E1E8070E7003C772F /* MSButton.swift in Sources */,
+				9C81B40E1E8AAF2F00C281B8 /* PersonTableViewCell.swift in Sources */,
 				9CC3846F1E7C17AD00595171 /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/IOS/SwiftSeedProject/SwiftSeedProject/Domain/Models/Person.swift
+++ b/IOS/SwiftSeedProject/SwiftSeedProject/Domain/Models/Person.swift
@@ -1,0 +1,17 @@
+//
+//  Person.swift
+//  SwiftSeedProject
+//
+//  Created by Mugu on 3/28/17.
+//  Copyright © 2017 Making Sense. All rights reserved.
+//
+
+import Foundation
+
+class Person : NSObject {
+    var name: String!
+    
+    public init(dataModel: PersonDataModel) {
+        name = dataModel.name
+    }
+}

--- a/IOS/SwiftSeedProject/SwiftSeedProject/Domain/Protocols/DataProvider.swift
+++ b/IOS/SwiftSeedProject/SwiftSeedProject/Domain/Protocols/DataProvider.swift
@@ -1,0 +1,13 @@
+//
+//  IDataLocator.swift
+//  SwiftSeedProject
+//
+//  Created by Mugu on 3/28/17.
+//  Copyright © 2017 Making Sense. All rights reserved.
+//
+
+import Foundation
+
+protocol DataProvider {
+    func getEntities<T: AnyObject>() -> [T]
+}

--- a/IOS/SwiftSeedProject/SwiftSeedProject/Domain/Services/PersonService.swift
+++ b/IOS/SwiftSeedProject/SwiftSeedProject/Domain/Services/PersonService.swift
@@ -1,0 +1,26 @@
+//
+//  PersonService.swift
+//  SwiftSeedProject
+//
+//  Created by Mugu on 3/28/17.
+//  Copyright © 2017 Making Sense. All rights reserved.
+//
+
+import Foundation
+
+open class PersonService {
+    let dataProvider : InMemoryDataProvider
+    
+    var persons = [Person]()
+    
+    init() {
+        dataProvider = InMemoryDataProvider()
+        let result : [AnyObject] = dataProvider.getEntities()
+        
+        for object in result {
+            let person = Person(dataModel: object as! PersonDataModel)
+            persons.append(person)
+        }
+    }
+    
+}

--- a/IOS/SwiftSeedProject/SwiftSeedProject/Infrastructure/Persistence/Implementations/InMemoryDataProvider.swift
+++ b/IOS/SwiftSeedProject/SwiftSeedProject/Infrastructure/Persistence/Implementations/InMemoryDataProvider.swift
@@ -1,0 +1,25 @@
+//
+//  BadExampleDataProvider.swift
+//  SwiftSeedProject
+//
+//  Created by Mugu on 3/29/17.
+//  Copyright © 2017 Making Sense. All rights reserved.
+//
+
+import Foundation
+
+class InMemoryDataProvider  {
+    let entities : [AnyObject] = [
+        PersonDataModel(name: "Marcelo"),
+        PersonDataModel(name: "Lucas"),
+        PersonDataModel(name: "Brian"),
+        PersonDataModel(name: "Mauro"),
+        PersonDataModel(name: "Mugu")
+    ]
+    
+    func getEntities<T: AnyObject>() -> [T] {
+        let result = entities.filter { $0 is T}
+        
+        return result as! [T]
+    }
+}

--- a/IOS/SwiftSeedProject/SwiftSeedProject/Infrastructure/Persistence/Models/PersonDataModel.swift
+++ b/IOS/SwiftSeedProject/SwiftSeedProject/Infrastructure/Persistence/Models/PersonDataModel.swift
@@ -1,0 +1,17 @@
+//
+//  PersonDataModel.swift
+//  SwiftSeedProject
+//
+//  Created by Mugu on 3/29/17.
+//  Copyright © 2017 Making Sense. All rights reserved.
+//
+
+import Foundation
+
+class PersonDataModel : AnyObject {
+    let name: String
+    
+    init(name: String) {
+        self.name = name
+    }
+}

--- a/IOS/SwiftSeedProject/SwiftSeedProject/Interfaces/Storyboards/Second.storyboard
+++ b/IOS/SwiftSeedProject/SwiftSeedProject/Interfaces/Storyboards/Second.storyboard
@@ -6,13 +6,14 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--SECOND-->
         <scene sceneID="jxP-Ds-v39">
             <objects>
-                <viewController title="SECOND" id="OAz-bt-S22" sceneMemberID="viewController">
+                <viewController title="SECOND" id="OAz-bt-S22" customClass="PersonTableViewController" customModule="SwiftSeedProject" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="0ym-fd-Yab"/>
                         <viewControllerLayoutGuide type="bottom" id="tZS-Fz-2wy"/>
@@ -21,23 +22,53 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Second" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="P83-pN-eog">
-                                <rect key="frame" x="158" y="323" width="59" height="21"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="Izf-Op-Uwg">
+                                <rect key="frame" x="28.5" y="50" width="318.5" height="567"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <prototypes>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="PersonCell" selectionStyle="default" indentationWidth="10" reuseIdentifier="PersonCell" id="gRa-ye-nlJ" customClass="PersonTableViewCell" customModule="SwiftSeedProject" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="28" width="318.5" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="gRa-ye-nlJ" id="Hbj-Gd-ORy">
+                                            <rect key="frame" x="0.0" y="0.0" width="318.5" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Name" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dm5-U1-RQh">
+                                                    <rect key="frame" x="31" y="13" width="255" height="17"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="dm5-U1-RQh" firstAttribute="centerX" secondItem="Hbj-Gd-ORy" secondAttribute="centerX" id="7Dm-EF-3PJ"/>
+                                                <constraint firstItem="dm5-U1-RQh" firstAttribute="centerY" secondItem="Hbj-Gd-ORy" secondAttribute="centerY" id="K9U-h9-5Ec"/>
+                                                <constraint firstItem="dm5-U1-RQh" firstAttribute="height" secondItem="Hbj-Gd-ORy" secondAttribute="height" multiplier="0.4" id="X2d-dj-49s"/>
+                                                <constraint firstItem="dm5-U1-RQh" firstAttribute="width" secondItem="Hbj-Gd-ORy" secondAttribute="width" multiplier="0.8" id="smO-oA-J4x"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <outlet property="lblName" destination="dm5-U1-RQh" id="49F-TD-N9a"/>
+                                        </connections>
+                                    </tableViewCell>
+                                </prototypes>
+                            </tableView>
                         </subviews>
                         <color key="backgroundColor" red="0.56202327029999999" green="0.72164272640000005" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstItem="P83-pN-eog" firstAttribute="centerX" secondItem="7ML-l9-PZ1" secondAttribute="centerX" id="9EC-Cg-gkJ"/>
-                            <constraint firstItem="P83-pN-eog" firstAttribute="centerY" secondItem="7ML-l9-PZ1" secondAttribute="centerY" id="dYR-L6-BuQ"/>
+                            <constraint firstItem="Izf-Op-Uwg" firstAttribute="centerX" secondItem="7ML-l9-PZ1" secondAttribute="centerX" id="BVa-oo-jnS"/>
+                            <constraint firstItem="Izf-Op-Uwg" firstAttribute="height" secondItem="7ML-l9-PZ1" secondAttribute="height" multiplier="0.85" id="ER6-sX-c5x"/>
+                            <constraint firstItem="Izf-Op-Uwg" firstAttribute="width" secondItem="7ML-l9-PZ1" secondAttribute="width" multiplier="0.85" id="JHa-3i-BSr"/>
+                            <constraint firstItem="Izf-Op-Uwg" firstAttribute="centerY" secondItem="7ML-l9-PZ1" secondAttribute="centerY" id="v4b-fc-d4l"/>
                         </constraints>
                     </view>
+                    <connections>
+                        <outlet property="tblView" destination="Izf-Op-Uwg" id="V5D-sj-f53"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="V4w-vj-9NK" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-185" y="649"/>
+            <point key="canvasLocation" x="-186.40000000000001" y="648.12593703148434"/>
         </scene>
     </scenes>
 </document>

--- a/IOS/SwiftSeedProject/SwiftSeedProject/Interfaces/ViewControllers/Person/PersonTableViewCell.swift
+++ b/IOS/SwiftSeedProject/SwiftSeedProject/Interfaces/ViewControllers/Person/PersonTableViewCell.swift
@@ -1,0 +1,18 @@
+//
+//  PersonTableViewCell.swift
+//  SwiftSeedProject
+//
+//  Created by Mugu on 3/28/17.
+//  Copyright © 2017 Making Sense. All rights reserved.
+//
+
+import UIKit
+
+class PersonTableViewCell: UITableViewCell {
+    @IBOutlet weak var lblName: UILabel!
+    static let identifier = "PersonCell"
+    
+    override func awakeFromNib() {
+        super.awakeFromNib()
+    }
+}

--- a/IOS/SwiftSeedProject/SwiftSeedProject/Interfaces/ViewControllers/PersonTableViewController.swift
+++ b/IOS/SwiftSeedProject/SwiftSeedProject/Interfaces/ViewControllers/PersonTableViewController.swift
@@ -1,0 +1,33 @@
+//
+//  PersonTableViewController.swift
+//  SwiftSeedProject
+//
+//  Created by Mugu on 3/27/17.
+//  Copyright © 2017 Making Sense. All rights reserved.
+//
+
+import UIKit
+
+class PersonTableViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
+    @IBOutlet weak var tblView: UITableView!
+    
+    var service: PersonService?
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        service = PersonService()
+        tblView.delegate = self
+        tblView.dataSource = self
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return (service?.persons.count)!
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: PersonTableViewCell.identifier, for: indexPath) as! PersonTableViewCell
+        cell.lblName.text = service?.persons[indexPath.row].name
+        
+        return cell
+    }
+}


### PR DESCRIPTION
## Background

As we discussed with @mvazquez-ms the idea was to create an example of how to abstract the data providers with their data models and use them in services in a running example. 

It's quite simple, but there are some things on generics that we couldn't make work as we really wanted to with Marce.

## Changes done

1. Modified 2nd storyboard to have a TableView and CustomCell.
2. Created new TableViewController and TableViewCell.
3. Created a Service to consume Data Provider.
4. Created a Data Provider Protocol to abstract it's functionality then implemented it with a simple example.

## Approvers required

@mvazquez-ms @lpelizzaMS @bsztamfater-ms  @mmaldini33 

## Additional Approvers

@AlphaGit  @andresmoschini  @matiasbeckerle  @mravinale 