### PR TITLE
[MLP-191] Fix problem with Bond library

### DIFF
--- a/IOS/SwiftSeedProject/Podfile
+++ b/IOS/SwiftSeedProject/Podfile
@@ -9,7 +9,7 @@ target 'SwiftSeedProject' do
 
   pod 'Dip', '5.0.4'
   pod 'Dip-UI', '1.0.2'
-  pod 'Bond', '6.2.3'
+  pod 'Bond', '6.2.4'
   pod 'Alamofire', '4.4'
   pod 'SwiftyJSON', '3.1.4'
   pod 'SDWebImage', '4.0.0'

--- a/IOS/SwiftSeedProject/Podfile.lock
+++ b/IOS/SwiftSeedProject/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
   - Alamofire (4.4.0)
-  - Bond (6.2.3):
+  - Bond (6.2.4):
     - Diff (~> 0.4)
     - ReactiveKit (~> 3.5.1)
   - Diff (0.5.3)
   - Dip (5.0.4)
   - Dip-UI (1.0.2):
     - Dip (~> 5.0)
-  - ReactiveKit (3.5.1)
+  - ReactiveKit (3.5.5)
   - SDWebImage (4.0.0):
     - SDWebImage/Core (= 4.0.0)
   - SDWebImage/Core (4.0.0)
@@ -15,7 +15,7 @@ PODS:
 
 DEPENDENCIES:
   - Alamofire (= 4.4)
-  - Bond (= 6.2.3)
+  - Bond (= 6.2.4)
   - Dip (= 5.0.4)
   - Dip-UI (= 1.0.2)
   - SDWebImage (= 4.0.0)
@@ -23,14 +23,14 @@ DEPENDENCIES:
 
 SPEC CHECKSUMS:
   Alamofire: dc44b1600b800eb63da6a19039a0083d62a6a62d
-  Bond: ef1d9efe6f5b60440979ed35187e468d7020b0ab
+  Bond: c54dc8e6ad4f2d4e3d60c680c25637a7824161df
   Diff: befa1d19c32726b2b36ce915d98793e2fbde8dcc
   Dip: 6460091adcf84ae8765f4927b85b49e6a3b67bfe
   Dip-UI: 7f03e0bc332fdda3cdf1d9a05125e5f30374dff1
-  ReactiveKit: aa0faf668053e7fddd6a07829ba3696741cbff37
+  ReactiveKit: ced30f9647912f74510bd8179790cf2dfc9454c8
   SDWebImage: 76a6348bdc74eb5a55dd08a091ef298e56b55e41
   SwiftyJSON: c2842d878f95482ffceec5709abc3d05680c0220
 
-PODFILE CHECKSUM: e420622f9bb09bf60fa2f1616283ad4bbd9b6823
+PODFILE CHECKSUM: 3ce4c514618289dc1c2b8ef882ced93c16cf4c15
 
-COCOAPODS: 1.2.0
+COCOAPODS: 1.2.1


### PR DESCRIPTION
# Background
We should fix a problem with the Bond Library.

# Changes done
I've updated the Bond library version because I've found that the problem looked like there was an issue with CocoaPods not correctly setting SWIFT_ACTIVE_COMPILATION_CONDITIONS. So it is related to a problem reported on Bond git. This is the [Link](https://github.com/ReactiveKit/Bond/issues/411) to the issue.

# Notes
I've committed the Podfile.lock file because we need this for the CI.

# Approvers required
@mvazquez-ms @mmaldini33 @bsztamfater-ms 