### PR TITLE
[MLP-192] Clean up code - warnings

### DIFF
--- a/IOS/SwiftSeedProject/Podfile
+++ b/IOS/SwiftSeedProject/Podfile
@@ -7,7 +7,7 @@ target 'SwiftSeedProject' do
 
   # Pods for SwiftSeedProject
 
-  pod 'Dip', '5.0.4'
+  pod 'Dip', '5.1'
   pod 'Dip-UI', '1.0.2'
   pod 'Bond', '6.2.4'
   pod 'Alamofire', '4.4'

--- a/IOS/SwiftSeedProject/Podfile.lock
+++ b/IOS/SwiftSeedProject/Podfile.lock
@@ -4,7 +4,7 @@ PODS:
     - Diff (~> 0.4)
     - ReactiveKit (~> 3.5.1)
   - Diff (0.5.3)
-  - Dip (5.0.4)
+  - Dip (5.1)
   - Dip-UI (1.0.2):
     - Dip (~> 5.0)
   - ReactiveKit (3.5.5)
@@ -16,7 +16,7 @@ PODS:
 DEPENDENCIES:
   - Alamofire (= 4.4)
   - Bond (= 6.2.4)
-  - Dip (= 5.0.4)
+  - Dip (= 5.1)
   - Dip-UI (= 1.0.2)
   - SDWebImage (= 4.0.0)
   - SwiftyJSON (= 3.1.4)
@@ -25,12 +25,12 @@ SPEC CHECKSUMS:
   Alamofire: dc44b1600b800eb63da6a19039a0083d62a6a62d
   Bond: c54dc8e6ad4f2d4e3d60c680c25637a7824161df
   Diff: befa1d19c32726b2b36ce915d98793e2fbde8dcc
-  Dip: 6460091adcf84ae8765f4927b85b49e6a3b67bfe
+  Dip: f5a7bd4e1a8af48516e4adc0952d6efc29015589
   Dip-UI: 7f03e0bc332fdda3cdf1d9a05125e5f30374dff1
   ReactiveKit: ced30f9647912f74510bd8179790cf2dfc9454c8
   SDWebImage: 76a6348bdc74eb5a55dd08a091ef298e56b55e41
   SwiftyJSON: c2842d878f95482ffceec5709abc3d05680c0220
 
-PODFILE CHECKSUM: 3ce4c514618289dc1c2b8ef882ced93c16cf4c15
+PODFILE CHECKSUM: 95ca610d990bb6024a4071c9ebdef3945f90c37c
 
 COCOAPODS: 1.2.1

--- a/IOS/SwiftSeedProject/SwiftSeedProject/Infrastructure/PersistenceData.swift
+++ b/IOS/SwiftSeedProject/SwiftSeedProject/Infrastructure/PersistenceData.swift
@@ -69,7 +69,6 @@ class PersistenceData: Persistence {
     
     public func addAll<T: PersistenceObject>(entity: [T], entityName: String) {
         preconditionFailure("This method must be completed")
-        entityHasChanged(entity: entityName)
     }
     
     public func save() {


### PR DESCRIPTION
# Background
We should have a free code of warnings.

# Changes done
I've updated the dip library version to "5.1" because the previous version (5.0.4) had a warning.
Also, I've changed the "PersistenceData" file because it had a warning on the "addAll" function.

# Notes
I've committed the Podfile.lock file because we need this for the CI.

# Approvers required
@mvazquez-ms @mmaldini33 @bsztamfater-ms